### PR TITLE
Update OSX bindings to support caps-lock

### DIFF
--- a/osx/Minimak.bundle/Contents/Resources/Minimak (12 Key).keylayout
+++ b/osx/Minimak.bundle/Contents/Resources/Minimak (12 Key).keylayout
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE keyboard PUBLIC "" "file://localhost/System/Library/DTDs/KeyboardLayout.dtd">
 <!--Created by Ukelele version 2.2.3 on 2012-10-23 at 10:50 (BST)-->
-<!--Last edited by Ukelele version 2.2.3 on 2012-10-23 at 10:55 (BST)-->
+<!--Last edited by Ukelele version 2.2.4 on 2013-09-09 at 15:16 (BST)-->
 <keyboard group="0" id="14242" name="Minimak (12 Key)" maxout="1">
     <layouts>
         <layout first="0" last="0" modifiers="30" mapSet="138"/>
@@ -269,8 +269,8 @@
         <keyMap index="2">
             <key code="0" action="12"/>
             <key code="1" output="S"/>
-            <key code="2" output="D"/>
-            <key code="3" output="F"/>
+            <key code="2" output="T"/>
+            <key code="3" output="R"/>
             <key code="4" output="H"/>
             <key code="5" output="G"/>
             <key code="6" output="Z"/>
@@ -282,9 +282,9 @@
             <key code="12" output="Q"/>
             <key code="13" output="W"/>
             <key code="14" action="6"/>
-            <key code="15" output="R"/>
+            <key code="15" output="F"/>
             <key code="16" action="17"/>
-            <key code="17" output="T"/>
+            <key code="17" output="K"/>
             <key code="18" output="1"/>
             <key code="19" output="2"/>
             <key code="20" output="3"/>
@@ -302,13 +302,13 @@
             <key code="32" action="15"/>
             <key code="33" output="["/>
             <key code="34" action="13"/>
-            <key code="35" output="P"/>
+            <key code="35" output=";"/>
             <key code="36" output="&#x000D;"/>
-            <key code="37" output="L"/>
-            <key code="38" output="J"/>
+            <key code="37" output="O"/>
+            <key code="38" output="N"/>
             <key code="39" output="&#x0027;"/>
-            <key code="40" output="K"/>
-            <key code="41" output=";"/>
+            <key code="40" output="E"/>
+            <key code="41" output="P"/>
             <key code="42" output="\"/>
             <key code="43" output=","/>
             <key code="44" output="/"/>

--- a/osx/Minimak.bundle/Contents/Resources/Minimak (4 Key).keylayout
+++ b/osx/Minimak.bundle/Contents/Resources/Minimak (4 Key).keylayout
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE keyboard PUBLIC "" "file://localhost/System/Library/DTDs/KeyboardLayout.dtd">
 <!--Created by Ukelele version 2.2.3 on 2012-10-23 at 10:50 (BST)-->
-<!--Last edited by Ukelele version 2.2.3 on 2012-10-23 at 10:52 (BST)-->
+<!--Last edited by Ukelele version 2.2.4 on 2013-09-09 at 15:16 (BST)-->
 <keyboard group="0" id="14242" name="Minimak (4 Key)" maxout="1">
     <layouts>
         <layout first="0" last="0" modifiers="30" mapSet="138"/>
@@ -269,7 +269,7 @@
         <keyMap index="2">
             <key code="0" action="12"/>
             <key code="1" output="S"/>
-            <key code="2" output="D"/>
+            <key code="2" output="T"/>
             <key code="3" output="F"/>
             <key code="4" output="H"/>
             <key code="5" output="G"/>
@@ -284,7 +284,7 @@
             <key code="14" action="6"/>
             <key code="15" output="R"/>
             <key code="16" action="17"/>
-            <key code="17" output="T"/>
+            <key code="17" output="K"/>
             <key code="18" output="1"/>
             <key code="19" output="2"/>
             <key code="20" output="3"/>
@@ -307,7 +307,7 @@
             <key code="37" output="L"/>
             <key code="38" output="J"/>
             <key code="39" output="&#x0027;"/>
-            <key code="40" output="K"/>
+            <key code="40" output="E"/>
             <key code="41" output=";"/>
             <key code="42" output="\"/>
             <key code="43" output=","/>

--- a/osx/Minimak.bundle/Contents/Resources/Minimak (8 Key).keylayout
+++ b/osx/Minimak.bundle/Contents/Resources/Minimak (8 Key).keylayout
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE keyboard PUBLIC "" "file://localhost/System/Library/DTDs/KeyboardLayout.dtd">
 <!--Created by Ukelele version 2.2.3 on 2012-10-23 at 10:50 (BST)-->
-<!--Last edited by Ukelele version 2.2.3 on 2012-10-23 at 10:53 (BST)-->
+<!--Last edited by Ukelele version 2.2.4 on 2013-09-09 at 15:16 (BST)-->
 <keyboard group="0" id="14242" name="Minimak (8 Key)" maxout="1">
     <layouts>
         <layout first="0" last="0" modifiers="30" mapSet="138"/>
@@ -269,7 +269,7 @@
         <keyMap index="2">
             <key code="0" action="12"/>
             <key code="1" output="S"/>
-            <key code="2" output="D"/>
+            <key code="2" output="T"/>
             <key code="3" output="F"/>
             <key code="4" output="H"/>
             <key code="5" output="G"/>
@@ -284,7 +284,7 @@
             <key code="14" action="6"/>
             <key code="15" output="R"/>
             <key code="16" action="17"/>
-            <key code="17" output="T"/>
+            <key code="17" output="K"/>
             <key code="18" output="1"/>
             <key code="19" output="2"/>
             <key code="20" output="3"/>
@@ -304,10 +304,10 @@
             <key code="34" action="13"/>
             <key code="35" output="P"/>
             <key code="36" output="&#x000D;"/>
-            <key code="37" output="L"/>
-            <key code="38" output="J"/>
+            <key code="37" output="O"/>
+            <key code="38" output="N"/>
             <key code="39" output="&#x0027;"/>
-            <key code="40" output="K"/>
+            <key code="40" output="E"/>
             <key code="41" output=";"/>
             <key code="42" output="\"/>
             <key code="43" output=","/>


### PR DESCRIPTION
Sorry for the messing around. This PR is correct and adds the caps-lock functionality to the OSX bindings.
